### PR TITLE
Included the css to hide the google plus aside.

### DIFF
--- a/sass/partials/_asides.scss
+++ b/sass/partials/_asides.scss
@@ -1,1 +1,2 @@
 @import "asides/github";
+@import "asides/googleplus";

--- a/sass/partials/asides/_googleplus.scss
+++ b/sass/partials/asides/_googleplus.scss
@@ -1,0 +1,26 @@
+.googleplus {
+  h1 {
+       -moz-box-shadow: none !important;
+    -webkit-box-shadow: none !important;
+         -o-box-shadow: none !important;
+            box-shadow: none !important;
+    border-bottom: 0px none !important;
+  }
+  a {
+    text-decoration: none;
+    white-space: normal !important;
+    line-height: 32px;
+
+    img {
+      float: left;
+      margin-right: 0.5em;
+      border: 0 none;
+    }
+  }
+}
+
+.googleplus-hidden {
+  position: absolute;
+  top: -1000em;
+  left: -1000em;
+}


### PR DESCRIPTION
When `googleplus_hidden` is set to true and `asides/googleplus.html` is included as a default aside, it was still showing up. I added the scss files that define the googleplus-hidden class so the aside would be hidden.
