### PR TITLE
fix #38, add "skip to content" link for a11y

### DIFF
--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -1,5 +1,6 @@
 {% capture root_url %}{{ site.root | strip_slash }}{% endcapture %}{% include head.html %}
   <body {% if page.body_id %} id="{{ page.body_id }}" {% endif %} {% if page.sidebar == false %} class="no-sidebar" {% endif %} {% if page.sidebar == 'collapse' or site.sidebar == 'collapse' %} class="collapse-sidebar sidebar-footer" {% endif %}>
+    <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
     <div id="wrap">
       <header role="banner">
         {% include navigation.html %}


### PR DESCRIPTION
CSS styles for this change already included in bootstrap 3, [link](http://getbootstrap.com/getting-started/#accessibility) with information.
