### PR TITLE
print only content

### DIFF
--- a/sass/custom/_styles.scss
+++ b/sass/custom/_styles.scss
@@ -18,3 +18,22 @@ html, body {
 footer[role=contentinfo] {
     height: 60px;
 }
+
+/* print page content only no header, footer and asides, works with any page layout */
+@media print {
+  body * {
+    visibility: hidden;
+  }
+  /* use .no-print if you want to hide something inside page-content from printing */
+  .no-print, .no-print * {
+    display: none !important;
+  }
+  .page-content, .page-content * {
+    visibility: visible;
+  }
+  .page-content {
+    position: absolute;
+    left: 0;
+    top: 0;
+  }
+}

--- a/source/_includes/head.html
+++ b/source/_includes/head.html
@@ -30,7 +30,7 @@
   {% comment %}
     screen.css is included after custom/head so it can override stuff like Bootstrap fonts etc.
   {% endcomment %}
-  <link href="{{ root_url }}/stylesheets/screen.css" media="screen, projection" rel="stylesheet" type="text/css">
+  <link href="{{ root_url }}/stylesheets/screen.css" media="screen, projection, print" rel="stylesheet" type="text/css">
 
   {% include google_analytics.html %}
 </head>


### PR DESCRIPTION
This change intended to make it easier to print site by hiding anything but content (including comments). In default installation it hides recent posts and footer.
Before this PR: [pdf](http://dump.bitcheese.net/files/ejofale/before_change.pdf)
After this PR: [pdf](http://dump.bitcheese.net/files/acekemo/after_change.pdf)
I can consider including footer to print. Will be happy to hear other people's opinion on my idea.